### PR TITLE
Simplify the skeleton type

### DIFF
--- a/Test/PolyCheck/TH/Predicate.hs
+++ b/Test/PolyCheck/TH/Predicate.hs
@@ -128,16 +128,3 @@ tvStrictlyPositiveCon a (datatypeName, args) = do
   allM f (zip3 varOccurs varSP args)
   where allM f xs = and <$> traverse f xs
         anyM f xs = or <$> traverse f xs
-
-resTypeRequired :: [Name] -> (Name, [Type]) -> Q Bool
-resTypeRequired as (datatypeName, args) = flip anyM as $ \a -> do
-  info <- reifyDT datatypeName
-  let vars = info & datatypeVars <&> tvName
-  let cons = info & datatypeCons
-  let f (var, arg) = do
-        b1 <- tvOccurs a arg
-        b2 <- allM (tvStrictlyPositive var) (concatMap constructorFields cons)
-        pure $ b1 && not b2
-  anyM f (zip vars args)
-  where allM f xs = and <$> traverse f xs
-        anyM f xs = or <$> traverse f xs

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -5,6 +5,7 @@
 module Main where
 
 import qualified StrictlyPositive
+import GHC.Generics (Generic)
 import Text.Show.Functions
 import Test.PolyCheck.TH (monomorphic)
 import Test.QuickCheck hiding (monomorphic)
@@ -43,9 +44,10 @@ prop3 :: (Eq a, Eq b) => [(a, b)] -> Bool
 prop3 l = l == reverse (reverse l)
 
 data Bar a = Bar1 (a -> a) | Bar2 (a -> a)
-  deriving (Show)
+  deriving (Show, Generic)
 instance (CoArbitrary a, Arbitrary a) => Arbitrary (Bar a) where
   arbitrary = oneof [Bar1 <$> arbitrary, Bar2 <$> arbitrary]
+instance (CoArbitrary a, Arbitrary a) => CoArbitrary (Bar a)
 
 data Foo a b c = Foo (Bar a) (Bar (Maybe a)) (c -> c)
   deriving (Show)


### PR DESCRIPTION
The skeleton type in theory replaces all strictly positive `a` by unit type, and replaces the rest by `a*`. This pull request simply replaces all the `a` by `a* + 1`, and let `refill a iota e := iota ()`. So the new code no longer needs to generate new skeleton types.